### PR TITLE
PIPELINE-1860 Added Papua New Guinea normalization pipeline

### DIFF
--- a/packages/libs/utils/utils/convert.py
+++ b/packages/libs/utils/utils/convert.py
@@ -1,3 +1,7 @@
+def list_to_dict(labels):
+    return {x.split("=")[0]: x.split("=")[1] for x in labels}
+
+
 def to_float(value):
     return float(value) if value is not None else None
 

--- a/packages/libs/utils/utils/dates.py
+++ b/packages/libs/utils/utils/dates.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 def prev_month_from_YYYYMMDD(dt_str):
@@ -12,3 +12,7 @@ def prev_month_from_YYYYMMDD(dt_str):
     dt = datetime.strptime(dt_str, "%Y%m%d")
     dt = dt - timedelta(days=1)
     return datetime.strftime(dt.replace(day=1), "%Y%m%d")
+
+
+def parse_yyyy_mm_dd_param(value, tzinfo=timezone.utc):
+    return datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=tzinfo)

--- a/packages/pipe-vms-ingestion/poetry.lock
+++ b/packages/pipe-vms-ingestion/poetry.lock
@@ -1929,6 +1929,17 @@ files = [
 ]
 
 [[package]]
+name = "pycountry"
+version = "24.6.1"
+description = "ISO country, subdivision, language, currency and script definitions and their translations"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycountry-24.6.1-py3-none-any.whl", hash = "sha256:f1a4fb391cd7214f8eefd39556d740adcc233c778a27f8942c8dca351d6ce06f"},
+    {file = "pycountry-24.6.1.tar.gz", hash = "sha256:b61b3faccea67f87d10c1f2b0fc0be714409e8fcdcc1315613174f6466c10221"},
+]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 description = "C parser in Python"
@@ -2907,4 +2918,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.11"
-content-hash = "339bed81388c171f4c4f77da1321b2756a06ede0d0b9eacdfba2ae0df331a04f"
+content-hash = "fd8cfbd98c760078cf742164a083fd856aa0319ec288ab25be8e70edbf96762e"

--- a/packages/pipe-vms-ingestion/pyproject-build.toml
+++ b/packages/pipe-vms-ingestion/pyproject-build.toml
@@ -31,6 +31,7 @@ packages = [
   pandas = "^2.2.2"
   haversine = "^2.8.1"
   openpyxl = "^3.1.5"
+  pycountry = "^24.6.1"
 
   [tool.poetry.group.dev.dependencies]
   autopep8 = "2.0.2"

--- a/packages/pipe-vms-ingestion/pyproject.toml
+++ b/packages/pipe-vms-ingestion/pyproject.toml
@@ -28,6 +28,7 @@ readme = 'README.md'
   pandas = "^2.2.2"
   haversine = "^2.8.1"
   openpyxl = "^3.1.5"
+  pycountry = "^24.6.1"
 
     [tool.poetry.dependencies.bigquery]
     path = "../libs/bigquery"

--- a/packages/pipe-vms-ingestion/tests/vms_ingestion/normalization/feeds/data/raw_png.json
+++ b/packages/pipe-vms-ingestion/tests/vms_ingestion/normalization/feeds/data/raw_png.json
@@ -1,0 +1,80 @@
+[
+  {
+    "timestamp": "2020-01-01 21:51:00.000000 UTC",
+    "callsign": "2ABC-9",
+    "shipname": "DIANA L.T",
+    "registry_number": null,
+    "internal_id": null,
+    "external_id": null,
+    "lat": 6.0341,
+    "lon": 125.1536,
+    "speed": null,
+    "course": null,
+    "flag": "PH"
+  },
+  {
+    "timestamp": "2020-01-01 22:21:00.000000 UTC",
+    "callsign": "2ABC-9",
+    "shipname": "DIANA L.T",
+    "registry_number": null,
+    "internal_id": null,
+    "external_id": null,
+    "lat": 6.0309,
+    "lon": 125.1559,
+    "speed": null,
+    "course": null,
+    "flag": "PH"
+  },
+  {
+    "timestamp": "2020-01-01 23:51:00.000000 UTC",
+    "callsign": "2ABC-9",
+    "shipname": "DIANA L.T",
+    "registry_number": null,
+    "internal_id": null,
+    "external_id": null,
+    "lat": 5.7718,
+    "lon": 125.0671,
+    "speed": null,
+    "course": null,
+    "flag": "PH"
+  },
+  {
+    "timestamp": "2020-01-01 09:46:00.000000 UTC",
+    "callsign": "P1V1234",
+    "shipname": "TIBURCIA 777",
+    "registry_number": null,
+    "internal_id": null,
+    "external_id": null,
+    "lat": -4.2012,
+    "lon": 152.1693,
+    "speed": null,
+    "course": null,
+    "flag": "PG"
+  },
+  {
+    "timestamp": "2020-01-01 11:46:00.000000 UTC",
+    "callsign": "P1V1234",
+    "shipname": "TIBURCIA 777",
+    "registry_number": null,
+    "internal_id": null,
+    "external_id": null,
+    "lat": -4.2012,
+    "lon": 152.1693,
+    "speed": null,
+    "course": null,
+    "flag": "PG"
+  },
+  {
+    "timestamp": "2020-01-01 20:16:00.000000 UTC",
+    "callsign": "P1V1234",
+    "shipname": "TIBURCIA 777",
+    "registry_number": null,
+    "internal_id": null,
+    "external_id": null,
+    "lat": -4.2012,
+    "lon": 152.1693,
+    "speed": null,
+    "course": null,
+    "flag": "PG"
+  }
+]

--- a/packages/pipe-vms-ingestion/tests/vms_ingestion/normalization/feeds/test_png_normalize.py
+++ b/packages/pipe-vms-ingestion/tests/vms_ingestion/normalization/feeds/test_png_normalize.py
@@ -1,0 +1,248 @@
+import os
+import unittest
+from datetime import date, datetime, timezone
+
+import apache_beam as beam
+from apache_beam import pvalue
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+from tests.util import pcol_equal_to, read_json
+from vms_ingestion.normalization import build_pipeline_options_with_defaults
+from vms_ingestion.normalization.feeds.png_normalize import PNGNormalize
+
+script_path = os.path.dirname(os.path.abspath(__file__))
+
+
+class TestPNGNormalize(unittest.TestCase):
+
+    options = build_pipeline_options_with_defaults(
+        argv=[
+            "--country_code=png",
+            '--source=""',
+            '--destination=""',
+            '--start_date=""',
+            '--end_date=""',
+        ]
+    )
+
+    # Our input data, which will make up the initial PCollection.
+    RECORDS = [
+        {
+            **x,
+            "timestamp": datetime.fromisoformat(
+                x["timestamp"].replace(".000000 UTC", "+00:00")
+            ),
+        }
+        for x in read_json(f"{script_path}/data/raw_png.json")
+    ]
+
+    # Our output data, which is the expected data that the final PCollection must match.
+    EXPECTED = [
+        {
+            "callsign": "2ABC-9",
+            "class_b_cs_flag": None,
+            "course": None,
+            "destination": None,
+            "flag": "PHL",
+            "heading": None,
+            "imo": None,
+            "ingested_at": None,
+            "lat": 6.0341,
+            "length": None,
+            "lon": 125.1536,
+            "msgid": "d3b1297766e3a4c4c7108a72c472c2b90be7ebfa19d068134e52da360fceaa6b",
+            "received_at": None,
+            "receiver": None,
+            "receiver_type": None,
+            "shipname": "DIANA L.T",
+            "shiptype": None,
+            "source": "PNG_VMS",
+            "source_fleet": None,
+            "source_provider": "IFIMS",
+            "source_ssvid": None,
+            "source_tenant": "PNG",
+            "source_type": "VMS",
+            "speed": None,
+            "ssvid": "72950e8718f89d55b4c92badd581498d598dd687a2e80e327b08cd82eee742b3",
+            "status": None,
+            "timestamp": datetime(2020, 1, 1, 21, 51, tzinfo=timezone.utc),
+            "timestamp_date": date(2020, 1, 1),
+            "type": "VMS",
+            "width": None,
+        },
+        {
+            "callsign": "2ABC-9",
+            "class_b_cs_flag": None,
+            "course": 144.4438366926064,
+            "destination": None,
+            "flag": "PHL",
+            "heading": None,
+            "imo": None,
+            "ingested_at": None,
+            "lat": 6.0309,
+            "length": None,
+            "lon": 125.1559,
+            "msgid": "df989dd2f2bd59d9a9a99bf17fbc9b98b0c41f0b00964063c86dc6351f7f21f6",
+            "received_at": None,
+            "receiver": None,
+            "receiver_type": None,
+            "shipname": "DIANA L.T",
+            "shiptype": None,
+            "source": "PNG_VMS",
+            "source_fleet": None,
+            "source_provider": "IFIMS",
+            "source_ssvid": None,
+            "source_tenant": "PNG",
+            "source_type": "VMS",
+            "speed": 0.4723259938755648,
+            "ssvid": "72950e8718f89d55b4c92badd581498d598dd687a2e80e327b08cd82eee742b3",
+            "status": None,
+            "timestamp": datetime(2020, 1, 1, 22, 21, tzinfo=timezone.utc),
+            "timestamp_date": date(2020, 1, 1),
+            "type": "VMS",
+            "width": None,
+        },
+        {
+            "callsign": "2ABC-9",
+            "class_b_cs_flag": None,
+            "course": 198.82926367912165,
+            "destination": None,
+            "flag": "PHL",
+            "heading": None,
+            "imo": None,
+            "ingested_at": None,
+            "lat": 5.7718,
+            "length": None,
+            "lon": 125.0671,
+            "msgid": "10c8b802ed0db2104cab6af56a30beabad3b480811e55e961524876f13c63100",
+            "received_at": None,
+            "receiver": None,
+            "receiver_type": None,
+            "shipname": "DIANA L.T",
+            "shiptype": None,
+            "source": "PNG_VMS",
+            "source_fleet": None,
+            "source_provider": "IFIMS",
+            "source_ssvid": None,
+            "source_tenant": "PNG",
+            "source_type": "VMS",
+            "speed": 10.957092649611726,
+            "ssvid": "72950e8718f89d55b4c92badd581498d598dd687a2e80e327b08cd82eee742b3",
+            "status": None,
+            "timestamp": datetime(2020, 1, 1, 23, 51, tzinfo=timezone.utc),
+            "timestamp_date": date(2020, 1, 1),
+            "type": "VMS",
+            "width": None,
+        },
+        {
+            "callsign": "P1V1234",
+            "class_b_cs_flag": None,
+            "course": None,
+            "destination": None,
+            "flag": "PNG",
+            "heading": None,
+            "imo": None,
+            "ingested_at": None,
+            "lat": -4.2012,
+            "length": None,
+            "lon": 152.1693,
+            "msgid": "a883412673d3b057614ca7a213f5f804b1d04dfc838f3d39e32e7b1ccee2ebaf",
+            "received_at": None,
+            "receiver": None,
+            "receiver_type": None,
+            "shipname": "TIBURCIA 777",
+            "shiptype": None,
+            "source": "PNG_VMS",
+            "source_fleet": None,
+            "source_provider": "IFIMS",
+            "source_ssvid": None,
+            "source_tenant": "PNG",
+            "source_type": "VMS",
+            "speed": None,
+            "ssvid": "3b0db4962e19f74c64234a1f9da2c58daae54b8da1ed09a2eb115b90d442209d",
+            "status": None,
+            "timestamp": datetime(2020, 1, 1, 9, 46, tzinfo=timezone.utc),
+            "timestamp_date": date(2020, 1, 1),
+            "type": "VMS",
+            "width": None,
+        },
+        {
+            "callsign": "P1V1234",
+            "class_b_cs_flag": None,
+            "course": 0.0,
+            "destination": None,
+            "flag": "PNG",
+            "heading": None,
+            "imo": None,
+            "ingested_at": None,
+            "lat": -4.2012,
+            "length": None,
+            "lon": 152.1693,
+            "msgid": "56c48762bfeb01233482830511cd480a1c2a310bb6b3b1b5755d3de07a77e399",
+            "received_at": None,
+            "receiver": None,
+            "receiver_type": None,
+            "shipname": "TIBURCIA 777",
+            "shiptype": None,
+            "source": "PNG_VMS",
+            "source_fleet": None,
+            "source_provider": "IFIMS",
+            "source_ssvid": None,
+            "source_tenant": "PNG",
+            "source_type": "VMS",
+            "speed": 0.0,
+            "ssvid": "3b0db4962e19f74c64234a1f9da2c58daae54b8da1ed09a2eb115b90d442209d",
+            "status": None,
+            "timestamp": datetime(2020, 1, 1, 11, 46, tzinfo=timezone.utc),
+            "timestamp_date": date(2020, 1, 1),
+            "type": "VMS",
+            "width": None,
+        },
+        {
+            "callsign": "P1V1234",
+            "class_b_cs_flag": None,
+            "course": 0.0,
+            "destination": None,
+            "flag": "PNG",
+            "heading": None,
+            "imo": None,
+            "ingested_at": None,
+            "lat": -4.2012,
+            "length": None,
+            "lon": 152.1693,
+            "msgid": "768a9080c927fd245b9c881ee6c02765a074c57be97b7b0a8abdb1687cf07403",
+            "received_at": None,
+            "receiver": None,
+            "receiver_type": None,
+            "shipname": "TIBURCIA 777",
+            "shiptype": None,
+            "source": "PNG_VMS",
+            "source_fleet": None,
+            "source_provider": "IFIMS",
+            "source_ssvid": None,
+            "source_tenant": "PNG",
+            "source_type": "VMS",
+            "speed": 0.0,
+            "ssvid": "3b0db4962e19f74c64234a1f9da2c58daae54b8da1ed09a2eb115b90d442209d",
+            "status": None,
+            "timestamp": datetime(2020, 1, 1, 20, 16, tzinfo=timezone.utc),
+            "timestamp_date": date(2020, 1, 1),
+            "type": "VMS",
+            "width": None,
+        },
+    ]
+
+    # Example test that tests the pipeline's transforms.
+    def test_normalize(self):
+        with TestPipeline(options=TestPNGNormalize.options) as p:
+
+            # Create a PCollection from the RECORDS static input data.
+            input = p | beam.Create(TestPNGNormalize.RECORDS)
+
+            # Run ALL the pipeline's transforms (in this case, the Normalize transform).
+            output: pvalue.PCollection = input | PNGNormalize(feed="png")
+
+            # Assert that the output PCollection matches the EXPECTED data.
+            assert_that(
+                output, pcol_equal_to(TestPNGNormalize.EXPECTED), label="CheckOutput"
+            )

--- a/packages/pipe-vms-ingestion/tests/vms_ingestion/normalization/transforms/test_filter_date_range.py
+++ b/packages/pipe-vms-ingestion/tests/vms_ingestion/normalization/transforms/test_filter_date_range.py
@@ -1,0 +1,56 @@
+import unittest
+from datetime import datetime, timedelta
+
+import apache_beam as beam
+from apache_beam import pvalue
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+from tests.util import pcol_equal_to
+from vms_ingestion.normalization import build_pipeline_options_with_defaults
+from vms_ingestion.normalization.transforms.filter_date_range import FilterDateRange
+
+
+class TestFilterDateRange(unittest.TestCase):
+    options = build_pipeline_options_with_defaults(
+        argv=[
+            "--country_code=bra",
+            '--source=""',
+            '--destination=""',
+            '--start_date=""',
+            '--end_date=""',
+        ]
+    )
+
+    # Tests the pipeline's transforms.
+    def test_filter_date_range(self):
+        with TestPipeline(options=TestFilterDateRange.options) as p:
+
+            start_date = datetime.fromisoformat("2024-01-02 00:00:00+00:00")
+            end_date = start_date + timedelta(days=1)
+
+            # Create a PCollection from the RECORDS static input data.
+            input = p | beam.Create(
+                [
+                    {"timestamp": start_date - timedelta(seconds=1)},
+                    {"timestamp": start_date},
+                    {"timestamp": end_date - timedelta(seconds=1)},
+                    {"timestamp": end_date},
+                ]
+            )
+
+            # Run the transform to test
+            output: pvalue.PCollection = input | FilterDateRange(
+                date_range=(start_date, end_date)
+            )
+
+            # Assert that the output PCollection matches the EXPECTED data.
+            assert_that(
+                output,
+                pcol_equal_to(
+                    [
+                        {"timestamp": start_date},
+                        {"timestamp": end_date - timedelta(seconds=1)},
+                    ]
+                ),
+                label="CheckOutput",
+            )

--- a/packages/pipe-vms-ingestion/tests/vms_ingestion/normalization/transforms/test_png_map_source_message.py
+++ b/packages/pipe-vms-ingestion/tests/vms_ingestion/normalization/transforms/test_png_map_source_message.py
@@ -1,0 +1,94 @@
+import unittest
+from datetime import datetime, timezone
+
+import apache_beam as beam
+from apache_beam import pvalue
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+from tests.util import pcol_equal_to
+from vms_ingestion.normalization import build_pipeline_options_with_defaults
+from vms_ingestion.normalization.transforms.png_map_source_message import (
+    PNGMapSourceMessage,
+)
+
+
+class TestPNGMapSourceMessage(unittest.TestCase):
+    options = build_pipeline_options_with_defaults(
+        argv=[
+            "--country_code=png",
+            '--source=""',
+            '--destination=""',
+            '--start_date=""',
+            '--end_date=""',
+        ]
+    )
+    # Our input data, which will make up the initial PCollection.
+    RECORDS = [
+        {
+            "timestamp": datetime.fromisoformat("2019-12-31 23:51:00+00:00"),
+            "callsign": "2ABC-9",
+            "shipname": "DIANA L.T",
+            "registry_number": None,
+            "internal_id": None,
+            "external_id": None,
+            "lat": 6.0341,
+            "lon": 125.2536,
+            "speed": None,
+            "course": None,
+            "flag": "PH",
+        },
+        {
+            "timestamp": datetime.fromisoformat("2020-01-01 00:51:00+00:00"),
+            "callsign": "2ABC-9",
+            "shipname": "DIANA L.T",
+            "registry_number": None,
+            "internal_id": None,
+            "external_id": None,
+            "lat": 6.0341,
+            "lon": 125.1536,
+            "speed": None,
+            "course": None,
+            "flag": "PH",
+        },
+    ]
+
+    # Our output data, which is the expected data that the final PCollection must match.
+    EXPECTED = [
+        {
+            "callsign": "2ABC-9",
+            "course": None,
+            "flag": "PHL",
+            "lat": 6.0341,
+            "lon": 125.2536,
+            "shipname": "DIANA L.T",
+            "speed": None,
+            "timestamp": datetime(2019, 12, 31, 23, 51, tzinfo=timezone.utc),
+        },
+        {
+            "callsign": "2ABC-9",
+            "course": 270.0052560184024,
+            "flag": "PHL",
+            "lat": 6.0341,
+            "lon": 125.1536,
+            "shipname": "DIANA L.T",
+            "speed": 5.970788583842863,
+            "timestamp": datetime(2020, 1, 1, 00, 51, tzinfo=timezone.utc),
+        },
+    ]
+
+    # Tests the transform.
+    def test_png_map_source_message(self):
+        with TestPipeline(options=TestPNGMapSourceMessage.options) as p:
+
+            # Create a PCollection from the RECORDS static input data.
+            input = p | beam.Create(TestPNGMapSourceMessage.RECORDS)
+
+            # Run ALL the pipeline's transforms (in this case, the Normalize transform).
+            output: pvalue.PCollection = input | PNGMapSourceMessage()
+
+            # Assert that the output PCollection matches the EXPECTED data.
+            assert_that(
+                output,
+                pcol_equal_to(TestPNGMapSourceMessage.EXPECTED),
+                label="CheckOutput",
+            )

--- a/packages/pipe-vms-ingestion/vms_ingestion/ingestion/excel_to_bq/pipeline.py
+++ b/packages/pipe-vms-ingestion/vms_ingestion/ingestion/excel_to_bq/pipeline.py
@@ -1,9 +1,9 @@
-import datetime as dt
-
 import apache_beam as beam
 from apache_beam.options.pipeline_options import GoogleCloudOptions
 from bigquery.table import clear_records, ensure_table_exists
 from common.transforms.pick_output_fields import PickOutputFields
+from utils.convert import list_to_dict
+from utils.dates import parse_yyyy_mm_dd_param
 from vms_ingestion.ingestion.excel_to_bq.feed_ingestion_factory import (
     FeedIngestionFactory,
 )
@@ -20,14 +20,6 @@ from vms_ingestion.ingestion.excel_to_bq.transforms.write_sink import (
     table_descriptor,
     table_schema,
 )
-
-
-def parse_yyyy_mm_dd_param(value):
-    return dt.datetime.strptime(value, "%Y-%m-%d")
-
-
-def list_to_dict(labels):
-    return {x.split("=")[0]: x.split("=")[1] for x in labels}
 
 
 class IngestionExcelToBQPipeline:

--- a/packages/pipe-vms-ingestion/vms_ingestion/normalization/feed_normalization_factory.py
+++ b/packages/pipe-vms-ingestion/vms_ingestion/normalization/feed_normalization_factory.py
@@ -7,6 +7,7 @@ from vms_ingestion.normalization.feeds.ecu_normalize import ECUNormalize
 from vms_ingestion.normalization.feeds.nor_normalize import NORNormalize
 from vms_ingestion.normalization.feeds.pan_normalize import PANNormalize
 from vms_ingestion.normalization.feeds.per_normalize import PERNormalize
+from vms_ingestion.normalization.feeds.png_normalize import PNGNormalize
 
 NORMALIZER_BY_FEED = {
     "blz": BLZNormalize,
@@ -17,6 +18,7 @@ NORMALIZER_BY_FEED = {
     "nor": NORNormalize,
     "pan": PANNormalize,
     "per": PERNormalize,
+    "png": PNGNormalize,
 }
 
 

--- a/packages/pipe-vms-ingestion/vms_ingestion/normalization/feeds/png_normalize.py
+++ b/packages/pipe-vms-ingestion/vms_ingestion/normalization/feeds/png_normalize.py
@@ -1,0 +1,27 @@
+import apache_beam as beam
+from vms_ingestion.normalization.transforms.map_normalized_message import (
+    MapNormalizedMessage,
+)
+from vms_ingestion.normalization.transforms.png_map_source_message import (
+    PNGMapSourceMessage,
+)
+
+
+class PNGNormalize(beam.PTransform):
+
+    def __init__(self, feed) -> None:
+        self.feed = feed
+        self.source_provider = "IFIMS"
+        self.source_format = "PNG_VMS"
+
+    def expand(self, pcoll):
+
+        return (
+            pcoll
+            | PNGMapSourceMessage()
+            | MapNormalizedMessage(
+                feed=self.feed,
+                source_provider=self.source_provider,
+                source_format=self.source_format,
+            )
+        )

--- a/packages/pipe-vms-ingestion/vms_ingestion/normalization/pipeline.py
+++ b/packages/pipe-vms-ingestion/vms_ingestion/normalization/pipeline.py
@@ -1,9 +1,9 @@
-import datetime as dt
-
 import apache_beam as beam
 from apache_beam.options.pipeline_options import GoogleCloudOptions
 from bigquery.table import clear_records, ensure_table_exists
 from common.transforms.pick_output_fields import PickOutputFields
+from utils.convert import list_to_dict
+from utils.dates import parse_yyyy_mm_dd_param
 from vms_ingestion.normalization.feed_normalization_factory import (
     FeedNormalizationFactory,
 )
@@ -22,14 +22,6 @@ from vms_ingestion.normalization.transforms.write_sink import (
 from vms_ingestion.options import CommonPipelineOptions
 
 
-def parse_yyyy_mm_dd_param(value):
-    return dt.datetime.strptime(value, "%Y-%m-%d")
-
-
-def list_to_dict(labels):
-    return {x.split("=")[0]: x.split("=")[1] for x in labels}
-
-
 class NormalizationPipeline:
     def __init__(self, options):
         self.pipeline = beam.Pipeline(options=options)
@@ -41,12 +33,8 @@ class NormalizationPipeline:
         self.source = params.source
         self.source_timestamp_field = params.source_timestamp_field
         self.destination = params.destination
-        self.start_date = parse_yyyy_mm_dd_param(params.start_date).replace(
-            tzinfo=dt.timezone.utc
-        )
-        self.end_date = parse_yyyy_mm_dd_param(params.end_date).replace(
-            tzinfo=dt.timezone.utc
-        )
+        self.start_date = parse_yyyy_mm_dd_param(params.start_date)
+        self.end_date = parse_yyyy_mm_dd_param(params.end_date)
         self.labels = list_to_dict(gCloudParams.labels)
 
         self.table_schema = table_schema()

--- a/packages/pipe-vms-ingestion/vms_ingestion/normalization/transforms/filter_date_range.py
+++ b/packages/pipe-vms-ingestion/vms_ingestion/normalization/transforms/filter_date_range.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+
+from apache_beam import Filter, PTransform
+
+
+class FilterDateRange(PTransform):
+    """Filter items whose timestamp field is inside the given date_rage.
+
+    `date_range` (tuple[datetime, datetime]): A tuple composed by (start_date, end_date),
+        the items will be filtered using the following condition:
+
+        `start_date >= pcoll[timestamp] > end_date`
+
+    input | FilterDateRange(date_range=(start_date, end_date))
+
+    """
+
+    def __init__(self, date_range: tuple[datetime, datetime], label=None) -> None:
+        super().__init__(label)
+        self.start_date, self.end_date = date_range
+        self.with_input_types
+
+    def expand(self, pcoll):
+        return pcoll | Filter(
+            lambda x: x["timestamp"] >= self.start_date
+            and x["timestamp"] < self.end_date
+        )

--- a/packages/pipe-vms-ingestion/vms_ingestion/normalization/transforms/png_map_source_message.py
+++ b/packages/pipe-vms-ingestion/vms_ingestion/normalization/transforms/png_map_source_message.py
@@ -1,0 +1,100 @@
+import functools
+
+import apache_beam as beam
+import pycountry
+from common.transforms.calculate_implied_course import calculate_implied_course
+from common.transforms.calculate_implied_speed import calculate_implied_speed_kt
+from shipdataprocess.normalize import normalize_callsign
+from utils.convert import to_float, to_string
+
+
+def prioritize_msg_with_name(group):
+    key, msgs = group
+    msgs_list = list(msgs)
+    # Giving priority to msgs that comes with name than others.
+    msgs_with_name = [msg for msg in msgs_list if msg["shipname"] is not None]
+
+    proposed_msg = msgs_list[0]
+    if len(msgs_with_name) > 0:
+        proposed_msg = msgs_with_name[0]
+
+    return proposed_msg
+
+
+def set_previous_attr(group):
+    k, msgs = group
+    msgs_list = list(msgs)
+    msgs_list.sort(key=lambda msg: msg["timestamp"])
+
+    def set_attr(a, b):
+        prev = a[-1] if len(a) > 0 else None
+        b["prev_timestamp"] = prev["timestamp"] if prev else None
+        b["prev_lat"] = prev["lat"] if prev else None
+        b["prev_lon"] = prev["lon"] if prev else None
+        a.append(b)
+        return a
+
+    return functools.reduce(set_attr, msgs_list, [])
+
+
+def implies_speed_and_course(msg):
+    res = msg.copy()
+    speed = res.pop("speed")
+    course = res.pop("course")
+    if not speed:
+        speed = calculate_implied_speed_kt(
+            msg["prev_timestamp"],
+            msg["prev_lat"],
+            msg["prev_lon"],
+            msg["timestamp"],
+            msg["lat"],
+            msg["lon"],
+        )
+    if not course:
+        course = calculate_implied_course(
+            msg["prev_lat"], msg["prev_lon"], msg["lat"], msg["lon"]
+        )
+    res["speed"] = speed
+    res["course"] = course
+    return res
+
+
+def get_country_alpha_3(flag):
+    if len(flag) == 2:
+        return pycountry.countries.get(alpha_2=flag).alpha_3
+    return flag
+
+
+def ensure_internal_id(msg):
+    return {
+        **msg,
+        "internal_id": (
+            msg["internal_id"] or normalize_callsign(to_string(msg["callsign"]))
+        ),
+    }
+
+
+def png_map_source_message(msg):
+    return {
+        "callsign": to_string(msg["callsign"]),
+        "course": to_float(msg["course"]),
+        "flag": get_country_alpha_3(msg.get("flag")),
+        "lat": to_float(msg["lat"]),
+        "lon": to_float(msg["lon"]),
+        "shipname": to_string(msg["shipname"]),
+        "speed": to_float(msg["speed"]),
+        "timestamp": msg["timestamp"],
+    }
+
+
+class PNGMapSourceMessage(beam.PTransform):
+    def expand(self, pcoll):
+        return (
+            pcoll
+            | "Ensure internal id" >> beam.Map(ensure_internal_id)
+            | "Group by id" >> beam.GroupBy(id=lambda msg: msg["internal_id"])
+            | "Set previous timestamp,lat,lon" >> beam.FlatMap(set_previous_attr)
+            | "Impling Speed and Course if not coming"
+            >> beam.Map(implies_speed_and_course)
+            | "Preliminary source fields mapping" >> beam.Map(png_map_source_message)
+        )

--- a/packages/pipe-vms-ingestion/vms_ingestion/normalization/transforms/read_source.py
+++ b/packages/pipe-vms-ingestion/vms_ingestion/normalization/transforms/read_source.py
@@ -11,7 +11,7 @@ SOURCE_QUERY_TEMPLATE = """
     FROM
       `{{source_table}}`
     WHERE
-      DATE({{source_timestamp_field}}) >= '{{start_date}}'
+      DATE(TIMESTAMP_ADD({{source_timestamp_field}}, INTERVAL 2 HOUR)) >= '{{start_date}}'
       AND DATE({{source_timestamp_field}}) < '{{end_date}}'
 """
 


### PR DESCRIPTION
https://globalfishingwatch.atlassian.net/browse/PIPELINE-1860
* Added PNG normalization pipeline
* Included additional positions from 2 hours before `start_date` so that implied speed and course can be calculated for the first position of every vessel in `start_date`, otherwise it was `null`
* Added `FilterDateRange` transformation to exclude those additional positions before `start_date` from the output so that they are not stored in BQ.